### PR TITLE
site: replace the deployed demo with a static homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,12 +170,16 @@ Common build events:
 
 ## Examples
 
-This repo includes a test-oriented Next.js preview app and a web shell that can
-apply edits, show the preview in an iframe, and render next-dev-bridge events.
+Runnable usage lives under [`examples/`](examples/). The repo includes a
+test-oriented Next.js preview app and a local web shell that can apply edits,
+show the preview in an iframe, and render next-dev-bridge events.
 
 ```sh
 bun run example:web
 ```
+
+The project website is a dependency-free static page in [`site/index.html`](site/index.html).
+It does not run the example or start a Next.js application.
 
 Run unit tests:
 

--- a/examples/next-dev-bridge-web/README.md
+++ b/examples/next-dev-bridge-web/README.md
@@ -31,29 +31,9 @@ node dev-server.cjs -p 3001 -H 127.0.0.1
 The wrapper still runs Next in dev mode, but it can inject the portal-hiding
 style into Next's internal compiler-error HTML before the iframe receives it.
 
-## Vercel + Sandbox
+This is a development example, not the project website. The public site is the
+dependency-free [`site/index.html`](../../site/index.html); it does not start a
+Next.js server, create a sandbox, or run this viewer.
 
-To deploy the viewer app on Vercel while still running the preview app with
-`next dev`, create a Vercel project with:
-
-```text
-Root Directory: examples/next-dev-bridge-web
-Framework Preset: Next.js
-Build Command: default
-Output Directory: default
-```
-
-The web app and the sandbox preview fixture depend on the published
-`next-dev-bridge@0.1.0` package, so no custom Vercel install or build command is
-required.
-
-No extra environment variable is required for the default Vercel deployment.
-When `VERCEL` is defined, the viewer API routes use Sandbox mode automatically.
-
-On first load, the deployed viewer creates an empty Vercel Sandbox, writes the
-bundled `preview-fixture` files to `preview/`, installs the fixture
-dependencies from npm, starts that fixture in Next dev mode through
-`dev-server.cjs`, and points the iframe at the sandbox URL.
-
-For non-Vercel testing, `NEXT_DEV_BRIDGE_CONTROL_MODE=sandbox` still forces
-Sandbox mode, and `NEXT_DEV_BRIDGE_CONTROL_MODE=local` forces local preview mode.
+Set `NEXT_DEV_BRIDGE_CONTROL_MODE=sandbox` to exercise Sandbox mode locally, or
+`NEXT_DEV_BRIDGE_CONTROL_MODE=local` to force the default local preview mode.

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,1031 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta
+      name="description"
+      content="next-dev-bridge turns Next.js development signals into a small, readable stream of build and runtime events."
+    />
+    <meta name="theme-color" content="#f4f1e8" />
+    <meta property="og:title" content="next-dev-bridge" />
+    <meta
+      property="og:description"
+      content="Readable build and runtime events for Next.js development tools."
+    />
+    <meta property="og:type" content="website" />
+    <title>next-dev-bridge — readable Next.js dev events</title>
+    <style>
+      :root {
+        --paper: #f4f1e8;
+        --paper-raised: #fffdf6;
+        --ink: #151515;
+        --muted: #66645d;
+        --line: #1c1c1c;
+        --orange: #ff5c35;
+        --lime: #d8ff52;
+        --blue: #2563eb;
+        --shadow: 7px 7px 0 var(--ink);
+        --radius: 18px;
+        --mono: "SFMono-Regular", "Cascadia Code", "Roboto Mono", Consolas,
+          monospace;
+        --sans: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI",
+          sans-serif;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      html {
+        scroll-behavior: smooth;
+      }
+
+      body {
+        min-width: 320px;
+        margin: 0;
+        background:
+          linear-gradient(rgba(21, 21, 21, 0.045) 1px, transparent 1px),
+          linear-gradient(90deg, rgba(21, 21, 21, 0.045) 1px, transparent 1px),
+          var(--paper);
+        background-size: 32px 32px;
+        color: var(--ink);
+        font-family: var(--sans);
+        font-size: 16px;
+        line-height: 1.55;
+      }
+
+      a {
+        color: inherit;
+      }
+
+      code,
+      pre {
+        font-family: var(--mono);
+      }
+
+      code {
+        font-size: 0.92em;
+      }
+
+      .wrap {
+        width: min(1120px, calc(100% - 40px));
+        margin-inline: auto;
+      }
+
+      .site-header {
+        position: sticky;
+        z-index: 20;
+        top: 0;
+        border-bottom: 2px solid var(--line);
+        background: rgba(244, 241, 232, 0.9);
+        backdrop-filter: blur(14px);
+      }
+
+      .nav {
+        display: flex;
+        min-height: 68px;
+        align-items: center;
+        justify-content: space-between;
+        gap: 24px;
+      }
+
+      .brand {
+        display: inline-flex;
+        align-items: center;
+        gap: 11px;
+        color: var(--ink);
+        font-family: var(--mono);
+        font-size: 0.92rem;
+        font-weight: 750;
+        letter-spacing: -0.03em;
+        text-decoration: none;
+      }
+
+      .brand-mark {
+        display: grid;
+        width: 28px;
+        height: 28px;
+        place-items: center;
+        border: 2px solid var(--line);
+        background: var(--lime);
+        box-shadow: 3px 3px 0 var(--ink);
+        font-size: 0.76rem;
+      }
+
+      .nav-links {
+        display: flex;
+        align-items: center;
+        gap: 22px;
+        font-size: 0.88rem;
+        font-weight: 700;
+      }
+
+      .nav-links a {
+        text-underline-offset: 4px;
+      }
+
+      .nav-links a:hover {
+        text-decoration-thickness: 2px;
+      }
+
+      .nav-cta {
+        border: 2px solid var(--line);
+        background: var(--ink);
+        color: white;
+        padding: 8px 13px;
+        text-decoration: none;
+      }
+
+      .announcement {
+        border-bottom: 2px solid var(--line);
+        background: var(--lime);
+      }
+
+      .announcement .wrap {
+        display: flex;
+        min-height: 38px;
+        align-items: center;
+        justify-content: center;
+        gap: 10px;
+        font-family: var(--mono);
+        font-size: 0.75rem;
+        font-weight: 700;
+        letter-spacing: 0.02em;
+        text-align: center;
+      }
+
+      .hero {
+        display: grid;
+        grid-template-columns: minmax(0, 1.08fr) minmax(380px, 0.92fr);
+        gap: 64px;
+        align-items: center;
+        padding-block: 96px 110px;
+      }
+
+      .eyebrow {
+        display: inline-flex;
+        align-items: center;
+        gap: 10px;
+        margin: 0 0 20px;
+        font-family: var(--mono);
+        font-size: 0.76rem;
+        font-weight: 750;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+      }
+
+      .eyebrow::before {
+        width: 10px;
+        height: 10px;
+        border: 2px solid var(--line);
+        background: var(--orange);
+        content: "";
+      }
+
+      h1,
+      h2,
+      h3,
+      p {
+        margin-top: 0;
+      }
+
+      h1,
+      h2,
+      h3 {
+        letter-spacing: -0.055em;
+      }
+
+      h1 {
+        max-width: 700px;
+        margin-bottom: 26px;
+        font-size: clamp(3.5rem, 8vw, 7.2rem);
+        font-weight: 780;
+        line-height: 0.88;
+      }
+
+      h1 .accent {
+        position: relative;
+        z-index: 0;
+        white-space: nowrap;
+      }
+
+      h1 .accent::after {
+        position: absolute;
+        z-index: -1;
+        right: -0.05em;
+        bottom: 0.04em;
+        left: -0.04em;
+        height: 0.25em;
+        background: var(--orange);
+        content: "";
+        transform: rotate(-1.5deg);
+      }
+
+      .lede {
+        max-width: 620px;
+        margin-bottom: 32px;
+        color: #494842;
+        font-size: clamp(1.08rem, 2vw, 1.28rem);
+      }
+
+      .actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 12px;
+      }
+
+      .button {
+        display: inline-flex;
+        min-height: 48px;
+        align-items: center;
+        justify-content: center;
+        border: 2px solid var(--line);
+        padding: 10px 18px;
+        font-weight: 750;
+        text-decoration: none;
+        transition: transform 140ms ease, box-shadow 140ms ease;
+      }
+
+      .button:hover {
+        transform: translate(-2px, -2px);
+      }
+
+      .button-primary {
+        background: var(--ink);
+        box-shadow: 5px 5px 0 var(--orange);
+        color: white;
+      }
+
+      .button-primary:hover {
+        box-shadow: 7px 7px 0 var(--orange);
+      }
+
+      .button-secondary {
+        background: var(--paper-raised);
+        box-shadow: 5px 5px 0 var(--ink);
+      }
+
+      .button-secondary:hover {
+        box-shadow: 7px 7px 0 var(--ink);
+      }
+
+      .monitor {
+        overflow: hidden;
+        border: 2px solid var(--line);
+        border-radius: var(--radius);
+        background: #111;
+        box-shadow: 10px 10px 0 var(--orange);
+        color: #f8f8f4;
+        transform: rotate(1.2deg);
+      }
+
+      .monitor-bar {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        border-bottom: 1px solid #353535;
+        padding: 13px 16px;
+        color: #a9a9a2;
+        font-family: var(--mono);
+        font-size: 0.72rem;
+      }
+
+      .window-dots {
+        display: flex;
+        gap: 6px;
+      }
+
+      .window-dots i {
+        width: 9px;
+        height: 9px;
+        border-radius: 999px;
+        background: #4b4b4b;
+      }
+
+      .window-dots i:first-child {
+        background: var(--orange);
+      }
+
+      .monitor-body {
+        padding: 16px 18px 22px;
+        font-family: var(--mono);
+        font-size: clamp(0.72rem, 1.4vw, 0.84rem);
+      }
+
+      .event {
+        display: grid;
+        grid-template-columns: 9px minmax(130px, auto) 1fr;
+        gap: 12px;
+        align-items: start;
+        border-bottom: 1px solid #292929;
+        padding: 13px 0;
+      }
+
+      .event:last-child {
+        border-bottom: 0;
+      }
+
+      .event-dot {
+        width: 8px;
+        height: 8px;
+        margin-top: 5px;
+        border-radius: 999px;
+        background: var(--lime);
+        box-shadow: 0 0 0 3px rgba(216, 255, 82, 0.13);
+      }
+
+      .event.error .event-dot {
+        background: var(--orange);
+        box-shadow: 0 0 0 3px rgba(255, 92, 53, 0.15);
+      }
+
+      .event-type {
+        color: white;
+        font-weight: 700;
+      }
+
+      .event-detail {
+        color: #92928c;
+        text-align: right;
+      }
+
+      .monitor-status {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        margin-top: 16px;
+        border: 1px solid #3a3a3a;
+        background: #191919;
+        padding: 11px 12px;
+        color: #b9b9b2;
+      }
+
+      .monitor-status strong {
+        color: var(--lime);
+        font-weight: 650;
+      }
+
+      .section {
+        border-top: 2px solid var(--line);
+        padding-block: 92px;
+      }
+
+      .section-heading {
+        display: grid;
+        grid-template-columns: 0.7fr 1.3fr;
+        gap: 60px;
+        align-items: end;
+        margin-bottom: 44px;
+      }
+
+      .section-heading h2 {
+        margin-bottom: 0;
+        font-size: clamp(2.7rem, 6vw, 5.4rem);
+        line-height: 0.95;
+      }
+
+      .section-heading p {
+        max-width: 580px;
+        margin: 0;
+        color: var(--muted);
+        font-size: 1.08rem;
+      }
+
+      .feature-grid {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 18px;
+      }
+
+      .feature {
+        min-height: 250px;
+        border: 2px solid var(--line);
+        background: var(--paper-raised);
+        padding: 25px;
+      }
+
+      .feature:nth-child(2) {
+        background: var(--lime);
+      }
+
+      .feature:nth-child(3) {
+        background: #dfe9ff;
+      }
+
+      .feature-number {
+        display: block;
+        margin-bottom: 54px;
+        font-family: var(--mono);
+        font-size: 0.72rem;
+        font-weight: 750;
+      }
+
+      .feature h3 {
+        margin-bottom: 12px;
+        font-size: 1.55rem;
+      }
+
+      .feature p {
+        margin-bottom: 0;
+        color: #4d4c46;
+      }
+
+      .quickstart {
+        background: var(--ink);
+        color: white;
+      }
+
+      .quickstart .section-heading p {
+        color: #aaa9a1;
+      }
+
+      .quickstart .eyebrow::before {
+        background: var(--lime);
+        border-color: white;
+      }
+
+      .install-line {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 20px;
+        margin-bottom: 20px;
+        border: 1px solid #414141;
+        background: #0d0d0d;
+        padding: 18px 20px;
+        color: #d7d7d0;
+        font-family: var(--mono);
+      }
+
+      .install-line span:first-child {
+        color: #74746f;
+        user-select: none;
+      }
+
+      .install-line strong {
+        color: var(--lime);
+        font-weight: 500;
+      }
+
+      .install-line small {
+        color: #74746f;
+      }
+
+      .code-grid {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 18px;
+      }
+
+      .code-card {
+        overflow: hidden;
+        border: 1px solid #414141;
+        background: #0d0d0d;
+      }
+
+      .code-card-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        border-bottom: 1px solid #333;
+        padding: 12px 16px;
+        color: #8d8d87;
+        font-family: var(--mono);
+        font-size: 0.72rem;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+
+      .code-card-header b {
+        color: var(--orange);
+        font-weight: 600;
+      }
+
+      pre {
+        overflow-x: auto;
+        min-height: 265px;
+        margin: 0;
+        padding: 22px;
+        font-size: 0.8rem;
+        line-height: 1.7;
+        tab-size: 2;
+      }
+
+      .token-keyword,
+      .token-string {
+        color: var(--lime);
+      }
+
+      .token-function {
+        color: #8eb3ff;
+      }
+
+      .token-comment {
+        color: #777771;
+      }
+
+      .compatibility {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 18px;
+      }
+
+      .compat-card {
+        border: 2px solid var(--line);
+        background: var(--paper-raised);
+        padding: 30px;
+      }
+
+      .compat-card h3 {
+        margin-bottom: 20px;
+        font-size: 2rem;
+      }
+
+      .version-list {
+        display: grid;
+        gap: 10px;
+      }
+
+      .version-row {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        border-top: 1px solid #c9c6bb;
+        padding-top: 10px;
+        font-family: var(--mono);
+        font-size: 0.82rem;
+      }
+
+      .status {
+        display: inline-flex;
+        align-items: center;
+        gap: 7px;
+        color: #365200;
+        font-weight: 750;
+      }
+
+      .status::before {
+        width: 8px;
+        height: 8px;
+        border-radius: 999px;
+        background: #73a900;
+        content: "";
+      }
+
+      .event-cloud {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 9px;
+      }
+
+      .event-cloud code {
+        border: 1px solid var(--line);
+        background: var(--paper);
+        padding: 7px 9px;
+        font-size: 0.73rem;
+      }
+
+      .closing {
+        display: grid;
+        grid-template-columns: 1fr auto;
+        gap: 40px;
+        align-items: center;
+        border: 2px solid var(--line);
+        background: var(--orange);
+        box-shadow: var(--shadow);
+        padding: clamp(28px, 6vw, 58px);
+      }
+
+      .closing h2 {
+        max-width: 750px;
+        margin-bottom: 12px;
+        font-size: clamp(2.5rem, 6vw, 5.6rem);
+        line-height: 0.92;
+      }
+
+      .closing p {
+        max-width: 600px;
+        margin-bottom: 0;
+        font-weight: 600;
+      }
+
+      .closing .button {
+        background: var(--paper-raised);
+        box-shadow: 5px 5px 0 var(--ink);
+        white-space: nowrap;
+      }
+
+      footer {
+        padding-block: 46px;
+      }
+
+      .footer-row {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 28px;
+        font-family: var(--mono);
+        font-size: 0.75rem;
+      }
+
+      .footer-links {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 18px;
+      }
+
+      @media (max-width: 860px) {
+        .hero,
+        .section-heading,
+        .code-grid,
+        .compatibility {
+          grid-template-columns: 1fr;
+        }
+
+        .hero {
+          gap: 52px;
+          padding-block: 72px 88px;
+        }
+
+        .monitor {
+          width: min(100%, 620px);
+          transform: none;
+        }
+
+        .section-heading {
+          gap: 22px;
+        }
+
+        .feature-grid {
+          grid-template-columns: 1fr;
+        }
+
+        .feature {
+          min-height: 0;
+        }
+
+        .feature-number {
+          margin-bottom: 34px;
+        }
+
+        .closing {
+          grid-template-columns: 1fr;
+        }
+
+        .closing .button {
+          width: fit-content;
+        }
+      }
+
+      @media (max-width: 600px) {
+        .wrap {
+          width: min(100% - 24px, 1120px);
+        }
+
+        .nav {
+          min-height: 60px;
+        }
+
+        .nav-links > a:not(.nav-cta) {
+          display: none;
+        }
+
+        .announcement .wrap {
+          padding-block: 7px;
+        }
+
+        h1 {
+          font-size: clamp(3.2rem, 18vw, 5.2rem);
+        }
+
+        .hero {
+          grid-template-columns: minmax(0, 1fr);
+        }
+
+        .monitor-body {
+          padding-inline: 13px;
+        }
+
+        .event {
+          grid-template-columns: 8px 1fr;
+        }
+
+        .event-detail {
+          grid-column: 2;
+          text-align: left;
+        }
+
+        .section {
+          padding-block: 70px;
+        }
+
+        .install-line {
+          align-items: flex-start;
+          flex-direction: column;
+        }
+
+        pre {
+          min-height: 0;
+          padding: 17px;
+          font-size: 0.72rem;
+        }
+
+        .compat-card {
+          padding: 22px;
+        }
+
+        .closing {
+          box-shadow: 5px 5px 0 var(--ink);
+        }
+
+        .footer-row {
+          align-items: flex-start;
+          flex-direction: column;
+        }
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        html {
+          scroll-behavior: auto;
+        }
+
+        .button {
+          transition: none;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <header class="site-header">
+      <nav class="nav wrap" aria-label="Primary navigation">
+        <a class="brand" href="#top" aria-label="next-dev-bridge home">
+          <span class="brand-mark" aria-hidden="true">↯</span>
+          <span>next-dev-bridge</span>
+        </a>
+        <div class="nav-links">
+          <a href="#quickstart">Quickstart</a>
+          <a
+            href="https://github.com/vercel-labs/next-dev-bridge/tree/main/examples"
+            >Examples</a
+          >
+          <a
+            class="nav-cta"
+            href="https://github.com/vercel-labs/next-dev-bridge"
+            >GitHub ↗</a
+          >
+        </div>
+      </nav>
+    </header>
+
+    <div class="announcement">
+      <div class="wrap">
+        <span>●</span>
+        <span>Next.js 16.2 + 16.3 HMR endpoints supported</span>
+      </div>
+    </div>
+
+    <main id="top">
+      <section class="hero wrap">
+        <div>
+          <p class="eyebrow">Development signal, normalized</p>
+          <h1>Know when Next <span class="accent">breaks.</span></h1>
+          <p class="lede">
+            Turn Next.js HMR noise into readable build and runtime events for
+            CLIs, preview shells, agents, and custom development tools.
+          </p>
+          <div class="actions">
+            <a class="button button-primary" href="#quickstart">Get started</a>
+            <a
+              class="button button-secondary"
+              href="https://github.com/vercel-labs/next-dev-bridge/tree/main/examples"
+              >Browse examples</a
+            >
+          </div>
+        </div>
+
+        <div class="monitor" aria-label="Example next-dev-bridge event stream">
+          <div class="monitor-bar">
+            <span class="window-dots" aria-hidden="true"><i></i><i></i><i></i></span>
+            <span>localhost:3000 · event stream</span>
+          </div>
+          <div class="monitor-body">
+            <div class="event">
+              <span class="event-dot"></span>
+              <span class="event-type">session:connected</span>
+              <span class="event-detail">/_next/hmr</span>
+            </div>
+            <div class="event">
+              <span class="event-dot"></span>
+              <span class="event-type">build:ready</span>
+              <span class="event-detail">warnings: 0</span>
+            </div>
+            <div class="event error">
+              <span class="event-dot"></span>
+              <span class="event-type">build:error</span>
+              <span class="event-detail">page.tsx:18:7</span>
+            </div>
+            <div class="event">
+              <span class="event-dot"></span>
+              <span class="event-type">build:recovered</span>
+              <span class="event-detail">42 ms</span>
+            </div>
+            <div class="monitor-status">
+              <span>current state</span>
+              <strong>● HEALTHY</strong>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="section">
+        <div class="wrap">
+          <div class="section-heading">
+            <div>
+              <p class="eyebrow">One small bridge</p>
+              <h2>Less parsing. More signal.</h2>
+            </div>
+            <p>
+              Next development servers emit useful information, but the transport
+              is built for Next itself. next-dev-bridge gives tools a compact,
+              stable vocabulary instead.
+            </p>
+          </div>
+
+          <div class="feature-grid">
+            <article class="feature">
+              <span class="feature-number">01 / BUILD STATE</span>
+              <h3>Errors you can render</h3>
+              <p>
+                Receive formatted compiler errors, warnings, recovery, and ready
+                states without rebuilding Next's overlay protocol.
+              </p>
+            </article>
+            <article class="feature">
+              <span class="feature-number">02 / RUNTIME STATE</span>
+              <h3>Browser failures included</h3>
+              <p>
+                Capture uncaught errors, rejected promises, and reported errors
+                with source-mapped frames when Next can provide them.
+              </p>
+            </article>
+            <article class="feature">
+              <span class="feature-number">03 / YOUR UI</span>
+              <h3>Bring your own surface</h3>
+              <p>
+                Feed an agent, terminal, iframe shell, status panel, or any other
+                development interface that needs trustworthy state.
+              </p>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="section quickstart" id="quickstart">
+        <div class="wrap">
+          <div class="section-heading">
+            <div>
+              <p class="eyebrow">Quickstart</p>
+              <h2>Connect in a few lines.</h2>
+            </div>
+            <p>
+              Use the Node observer beside a running dev server, or the browser
+              observer inside a preview. The runnable setups stay in the examples
+              directory.
+            </p>
+          </div>
+
+          <div class="install-line" aria-label="Installation command">
+            <code><span>$</span> npm install <strong>next-dev-bridge</strong></code>
+            <small>ESM · Node 18+</small>
+          </div>
+
+          <div class="code-grid">
+            <article class="code-card">
+              <div class="code-card-header">
+                <span>Node observer</span><b>server.mjs</b>
+              </div>
+              <pre><code><span class="token-keyword">import</span> { connect } <span class="token-keyword">from</span> <span class="token-string">'next-dev-bridge'</span>
+
+<span class="token-keyword">const</span> connection = <span class="token-function">connect</span>(
+  { url: <span class="token-string">'http://localhost:3000'</span> },
+  (event, state) =&gt; {
+    <span class="token-keyword">if</span> (event.type === <span class="token-string">'build:error'</span>) {
+      console.<span class="token-function">log</span>(event.errors)
+    }
+  }
+)
+
+process.<span class="token-function">once</span>(<span class="token-string">'SIGINT'</span>, () =&gt; {
+  connection.<span class="token-function">stop</span>()
+})</code></pre>
+            </article>
+
+            <article class="code-card">
+              <div class="code-card-header">
+                <span>Browser observer</span><b>preview.ts</b>
+              </div>
+              <pre><code><span class="token-keyword">import</span> { observeNextDev } <span class="token-keyword">from</span>
+  <span class="token-string">'next-dev-bridge/client'</span>
+
+<span class="token-keyword">const</span> observer = <span class="token-function">observeNextDev</span>(
+  (event, state) =&gt; {
+    window.parent.<span class="token-function">postMessage</span>({
+      type: <span class="token-string">'next-dev-bridge:event'</span>,
+      event,
+      state,
+    }, <span class="token-string">'*'</span>)
+  }
+)
+
+window.<span class="token-function">addEventListener</span>(<span class="token-string">'pagehide'</span>, () =&gt;
+  observer.<span class="token-function">stop</span>()
+)</code></pre>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="section">
+        <div class="wrap">
+          <div class="section-heading">
+            <div>
+              <p class="eyebrow">The contract</p>
+              <h2>Small surface. Clear states.</h2>
+            </div>
+            <p>
+              The bridge owns connection lifecycle and state tracking, while your
+              code decides how events should look and what should happen next.
+            </p>
+          </div>
+
+          <div class="compatibility">
+            <article class="compat-card">
+              <h3>Compatibility</h3>
+              <div class="version-list">
+                <div class="version-row">
+                  <span>Next.js 16.2</span><span class="status">tested</span>
+                </div>
+                <div class="version-row">
+                  <span>Next.js 16.3</span><span class="status">tested</span>
+                </div>
+                <div class="version-row">
+                  <span>Node.js 18+</span><span class="status">supported</span>
+                </div>
+              </div>
+            </article>
+
+            <article class="compat-card">
+              <h3>Readable events</h3>
+              <div class="event-cloud" aria-label="Common event names">
+                <code>build:ready</code>
+                <code>build:error</code>
+                <code>build:recovered</code>
+                <code>runtime:error</code>
+                <code>session:connected</code>
+                <code>session:disconnected</code>
+                <code>observer:error</code>
+              </div>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="section">
+        <div class="wrap">
+          <div class="closing">
+            <div>
+              <p class="eyebrow">Open source · MIT</p>
+              <h2>Build a calmer dev loop.</h2>
+              <p>
+                Read the API reference, inspect the local examples, and wire Next
+                development state into your own tool.
+              </p>
+            </div>
+            <a
+              class="button"
+              href="https://github.com/vercel-labs/next-dev-bridge"
+              >View on GitHub ↗</a
+            >
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <div class="footer-row wrap">
+        <span>next-dev-bridge / MIT</span>
+        <div class="footer-links">
+          <a href="https://www.npmjs.com/package/next-dev-bridge">npm</a>
+          <a href="https://github.com/vercel-labs/next-dev-bridge/blob/main/docs/API.md"
+            >API</a
+          >
+          <a href="https://github.com/vercel-labs/next-dev-bridge/tree/main/examples"
+            >Examples</a
+          >
+          <a href="https://github.com/vercel-labs/next-dev-bridge">Source</a>
+        </div>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/site/index.html
+++ b/site/index.html
@@ -8,6 +8,10 @@
       content="Readable build and runtime events for Next.js development tools."
     />
     <meta name="theme-color" content="#ffffff" />
+    <link
+      rel="icon"
+      href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Cpath fill='%23f5df00' d='M16 0a16 16 0 0 1 16 16H0A16 16 0 0 1 16 0Z'/%3E%3Cpath d='M0 16h32a16 16 0 0 1-32 0Z'/%3E%3C/svg%3E"
+    />
     <title>next-dev-bridge</title>
     <style>
       :root {
@@ -44,42 +48,58 @@
 
       .page {
         width: min(760px, calc(100% - 48px));
-        margin-left: clamp(24px, 8vw, 120px);
+        margin-left: 40px;
       }
 
       header {
         display: flex;
-        height: 72px;
+        height: 60px;
         align-items: center;
         justify-content: space-between;
         border-bottom: 1px solid var(--border);
       }
 
       .brand {
+        display: inline-flex;
+        align-items: center;
+        gap: 9px;
         font-size: 15px;
         font-weight: 600;
         letter-spacing: -0.02em;
         text-decoration: none;
       }
 
-      .github {
+      .brand-icon {
+        width: 16px;
+        height: 16px;
+        flex: 0 0 auto;
+        border-radius: 50%;
+        background: linear-gradient(to bottom, #f5df00 0 50%, #171717 50% 100%);
+      }
+
+      .header-links {
+        display: flex;
+        gap: 16px;
+      }
+
+      .header-links a {
         color: var(--muted);
         font-size: 14px;
         text-decoration: none;
       }
 
-      .github:hover,
+      .header-links a:hover,
       footer a:hover {
         color: var(--foreground);
       }
 
       main {
-        padding: 112px 0 80px;
+        padding: 60px 0 48px;
       }
 
       .hero {
         max-width: 720px;
-        padding-bottom: 104px;
+        padding-bottom: 52px;
       }
 
       h1,
@@ -89,59 +109,138 @@
       }
 
       h1 {
-        max-width: 680px;
-        margin-bottom: 28px;
-        font-size: clamp(54px, 8vw, 88px);
+        max-width: 600px;
+        margin-bottom: 20px;
+        font-size: clamp(40px, 5vw, 56px);
         font-weight: 650;
-        letter-spacing: -0.075em;
-        line-height: 0.96;
+        letter-spacing: -0.065em;
+        line-height: 1;
       }
 
       .lede {
         max-width: 590px;
-        margin-bottom: 34px;
+        margin-bottom: 22px;
         color: var(--muted);
         font-size: 20px;
         letter-spacing: -0.025em;
         line-height: 1.5;
       }
 
-      .actions {
+      .hero-links {
         display: flex;
         flex-wrap: wrap;
-        gap: 10px;
+        gap: 18px;
+        margin: 0;
+        font-size: 14px;
       }
 
-      .button {
-        display: inline-flex;
-        height: 44px;
-        align-items: center;
-        justify-content: center;
+      .hero-links a {
+        text-decoration-color: #b5b5b5;
+        text-underline-offset: 4px;
+      }
+
+      .hero-links a:hover {
+        text-decoration-color: var(--foreground);
+      }
+
+      .signal-demo {
+        width: min(100%, 620px);
+        margin-top: 42px;
         border: 1px solid var(--border);
         border-radius: 8px;
-        padding: 0 17px;
-        font-size: 14px;
-        font-weight: 500;
-        text-decoration: none;
+        background: var(--subtle);
       }
 
-      .button-primary {
-        border-color: var(--foreground);
+      .signal-header,
+      .signal-row {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 20px;
+      }
+
+      .signal-header {
+        border-bottom: 1px solid var(--border);
+        padding: 13px 15px;
+        color: var(--muted);
+        font-size: 12px;
+      }
+
+      .signal-path {
+        font-family: var(--mono);
+      }
+
+      .listening {
+        display: inline-flex;
+        align-items: center;
+        gap: 7px;
+      }
+
+      .listening::before {
+        width: 6px;
+        height: 6px;
+        border-radius: 999px;
         background: var(--foreground);
-        color: white;
+        content: "";
+        animation: blink 0.7s ease-in-out infinite;
       }
 
-      .button:hover {
-        background: #f2f2f2;
+      .signal-list {
+        padding: 3px 15px;
       }
 
-      .button-primary:hover {
-        background: #333333;
+      .signal-row {
+        min-height: 48px;
+        border-bottom: 1px solid var(--border);
+        opacity: 0.28;
+        font-family: var(--mono);
+        font-size: 12px;
+        animation: signal 2.1s ease-in-out infinite;
+        animation-delay: var(--delay);
+        animation-fill-mode: backwards;
+      }
+
+      .signal-row:last-child {
+        border-bottom: 0;
+      }
+
+      .signal-row code {
+        font-weight: 700;
+      }
+
+      .signal-row span {
+        color: var(--muted);
+        text-align: right;
+      }
+
+      @keyframes signal {
+        0%,
+        28% {
+          opacity: 1;
+          transform: translateX(0);
+        }
+
+        36%,
+        100% {
+          opacity: 0.28;
+          transform: translateX(-2px);
+        }
+      }
+
+      @keyframes blink {
+        0%,
+        100% {
+          opacity: 0.35;
+        }
+
+        50% {
+          opacity: 1;
+        }
       }
 
       section:not(.hero) {
         border-top: 1px solid var(--border);
-        padding: 72px 0;
+        padding: 50px 0;
       }
 
       h2 {
@@ -153,7 +252,7 @@
 
       .section-copy {
         max-width: 580px;
-        margin-bottom: 30px;
+        margin-bottom: 22px;
         color: var(--muted);
         font-size: 16px;
         line-height: 1.6;
@@ -185,17 +284,118 @@
         border: 1px solid var(--border);
         border-radius: 8px;
         background: var(--subtle);
-        padding: 22px;
+        padding: 18px;
         font-family: var(--mono);
         font-size: 13px;
         line-height: 1.7;
         tab-size: 2;
       }
 
+      .cli-output {
+        display: block;
+        margin-top: 18px;
+        color: var(--muted);
+      }
+
+      .cli-output strong {
+        color: var(--foreground);
+        font-weight: 700;
+      }
+
+      .logged-results {
+        display: grid;
+        gap: 5px;
+        margin-top: 18px;
+        border-top: 1px solid var(--border);
+        padding-top: 16px;
+        color: var(--muted);
+      }
+
+      .log-line {
+        display: block;
+        opacity: 0;
+        animation-duration: 2.4s;
+        animation-iteration-count: infinite;
+        animation-timing-function: steps(1, end);
+      }
+
+      .log-line:nth-child(1) {
+        animation-name: log-first;
+      }
+
+      .log-line:nth-child(2) {
+        animation-name: log-second;
+      }
+
+      .log-line:nth-child(3) {
+        animation-name: log-third;
+      }
+
+      .log-line strong {
+        color: var(--foreground);
+        font-weight: 700;
+      }
+
+      @keyframes log-first {
+        0%,
+        12%,
+        92%,
+        100% {
+          opacity: 0;
+        }
+
+        13%,
+        86% {
+          opacity: 1;
+        }
+      }
+
+      @keyframes log-second {
+        0%,
+        36%,
+        92%,
+        100% {
+          opacity: 0;
+        }
+
+        37%,
+        86% {
+          opacity: 1;
+        }
+      }
+
+      @keyframes log-third {
+        0%,
+        60%,
+        92%,
+        100% {
+          opacity: 0;
+        }
+
+        61%,
+        86% {
+          opacity: 1;
+        }
+      }
+
+      .keyword,
+      .api {
+        color: var(--foreground);
+        font-weight: 700;
+      }
+
+      .punctuation {
+        color: #a3a3a3;
+      }
+
+      .string {
+        color: #525252;
+      }
+
       .capabilities {
         display: grid;
         gap: 0;
-        margin: 34px 0 0;
+        margin: 24px 0 0;
         padding: 0;
         border-top: 1px solid var(--border);
         list-style: none;
@@ -206,7 +406,7 @@
         grid-template-columns: 150px 1fr;
         gap: 28px;
         border-bottom: 1px solid var(--border);
-        padding: 22px 0;
+        padding: 17px 0;
         font-size: 14px;
         line-height: 1.55;
       }
@@ -221,7 +421,7 @@
 
       footer {
         display: flex;
-        min-height: 110px;
+        min-height: 80px;
         align-items: center;
         justify-content: space-between;
         border-top: 1px solid var(--border);
@@ -249,15 +449,15 @@
         }
 
         main {
-          padding-top: 76px;
+          padding-top: 48px;
         }
 
         .hero {
-          padding-bottom: 76px;
+          padding-bottom: 44px;
         }
 
         h1 {
-          font-size: clamp(48px, 15vw, 68px);
+          font-size: clamp(38px, 11vw, 48px);
         }
 
         .lede {
@@ -265,7 +465,7 @@
         }
 
         section:not(.hero) {
-          padding: 56px 0;
+          padding: 42px 0;
         }
 
         .capabilities li {
@@ -286,32 +486,68 @@
         html {
           scroll-behavior: auto;
         }
+
+        .listening::before,
+        .log-line,
+        .signal-row {
+          animation: none;
+        }
+
+        .log-line,
+        .signal-row {
+          opacity: 1;
+          transform: none;
+        }
       }
     </style>
   </head>
   <body>
     <div class="page">
       <header>
-        <a class="brand" href="#top">next-dev-bridge</a>
-        <a class="github" href="https://github.com/vercel-labs/next-dev-bridge"
-          >GitHub ↗</a
-        >
+        <a class="brand" href="#top">
+          <span class="brand-icon" aria-hidden="true"></span>
+          <span>next-dev-bridge</span>
+        </a>
+        <nav class="header-links" aria-label="Project links">
+          <a href="https://www.npmjs.com/package/next-dev-bridge">npm</a>
+          <a href="https://github.com/vercel-labs/next-dev-bridge">github ↗</a>
+        </nav>
       </header>
 
       <main id="top">
         <section class="hero">
-          <h1>Development state, made readable.</h1>
+          <h1>Readable Next.js events</h1>
           <p class="lede">
-            A small bridge from Next.js development events to the tools you
-            build around them.
+            Readable build and runtime events for CLIs, preview shells, agents,
+            and custom development tools.
           </p>
-          <div class="actions">
-            <a class="button button-primary" href="#start">Get started</a>
+          <p class="hero-links">
+            <a href="#start">Get started</a>
             <a
-              class="button"
               href="https://github.com/vercel-labs/next-dev-bridge/tree/main/examples"
               >View examples</a
             >
+          </p>
+
+          <div class="signal-demo" aria-label="Example normalized event stream">
+            <div class="signal-header">
+              <span class="signal-path">Next dev → next-dev-bridge</span>
+              <span class="listening">listening</span>
+            </div>
+            <div class="signal-list">
+              <div class="signal-row" style="--delay: 0s">
+                <code>build:error</code>
+                <span>1 compiler issue</span>
+              </div>
+              <div class="signal-row" style="--delay: 0.7s">
+                <code>build:recovered</code>
+                <span>clean</span>
+              </div>
+              <div class="signal-row" style="--delay: 1.4s">
+                <code>runtime:error</code>
+                <span>mapped to source</span>
+              </div>
+            </div>
           </div>
         </section>
 
@@ -328,21 +564,37 @@
         </section>
 
         <section>
+          <h2>Agents Friendly</h2>
+          <p class="section-copy">
+            Let an agent watch a running app without opening the browser.
+          </p>
+          <pre class="code"><code><span class="punctuation">$</span> <span class="api">connect-next</span> <span class="string">http://localhost:3000</span>
+
+<span class="cli-output logged-results"><span class="log-line"><strong>&gt;&gt;&gt; [WATCHING]</strong> localhost:3000</span>
+<span class="log-line"><strong>&gt;&gt;&gt; [ERROR]</strong> count=1 change=shown</span>
+<span class="log-line"><strong>&gt;&gt;&gt; [RECOVERED]</strong> warnings=0</span></span></code></pre>
+        </section>
+
+        <section>
           <h2>Observe</h2>
           <p class="section-copy">
             Receive a compact event stream and decide how your interface should
             respond.
           </p>
-          <pre class="code"><code>import { connect } from 'next-dev-bridge'
+          <pre class="code"><code><span class="keyword">import</span> <span class="punctuation">{</span> <span class="api">connect</span> <span class="punctuation">}</span> <span class="keyword">from</span> <span class="string">'next-dev-bridge'</span>
 
-const connection = connect(
-  { url: 'http://localhost:3000' },
-  (event, state) =&gt; {
-    console.log(event.type, state.phase)
-  }
-)
+<span class="keyword">const</span> connection <span class="punctuation">=</span> <span class="api">connect</span><span class="punctuation">(</span>
+  <span class="punctuation">{</span> url<span class="punctuation">:</span> <span class="string">'http://localhost:3000'</span> <span class="punctuation">},</span>
+  <span class="punctuation">(</span>event<span class="punctuation">,</span> state<span class="punctuation">) =&gt; {</span>
+    console<span class="punctuation">.</span>log<span class="punctuation">(</span>event<span class="punctuation">.</span>type<span class="punctuation">,</span> state<span class="punctuation">.</span>phase<span class="punctuation">)</span>
+  <span class="punctuation">}</span>
+<span class="punctuation">)</span>
 
-process.once('SIGINT', () =&gt; connection.stop())</code></pre>
+process<span class="punctuation">.</span>once<span class="punctuation">(</span><span class="string">'SIGINT'</span><span class="punctuation">, () =&gt;</span> connection<span class="punctuation">.</span>stop<span class="punctuation">())</span>
+
+<span class="logged-results"><span class="log-line"><strong>build:ready</strong> ok</span>
+<span class="log-line"><strong>build:error</strong> error</span>
+<span class="log-line"><strong>build:recovered</strong> ok</span></span></code></pre>
         </section>
 
         <section>
@@ -368,9 +620,8 @@ process.once('SIGINT', () =&gt; connection.stop())</code></pre>
       </main>
 
       <footer>
-        <span>MIT licensed</span>
+        <a href="https://github.com/vercel-labs">vercel-labs</a>
         <div class="footer-links">
-          <a href="https://www.npmjs.com/package/next-dev-bridge">npm</a>
           <a href="https://github.com/vercel-labs/next-dev-bridge/blob/main/docs/API.md"
             >API</a
           >

--- a/site/index.html
+++ b/site/index.html
@@ -5,32 +5,20 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta
       name="description"
-      content="next-dev-bridge turns Next.js development signals into a small, readable stream of build and runtime events."
-    />
-    <meta name="theme-color" content="#f4f1e8" />
-    <meta property="og:title" content="next-dev-bridge" />
-    <meta
-      property="og:description"
       content="Readable build and runtime events for Next.js development tools."
     />
-    <meta property="og:type" content="website" />
-    <title>next-dev-bridge — readable Next.js dev events</title>
+    <meta name="theme-color" content="#ffffff" />
+    <title>next-dev-bridge</title>
     <style>
       :root {
-        --paper: #f4f1e8;
-        --paper-raised: #fffdf6;
-        --ink: #151515;
-        --muted: #66645d;
-        --line: #1c1c1c;
-        --orange: #ff5c35;
-        --lime: #d8ff52;
-        --blue: #2563eb;
-        --shadow: 7px 7px 0 var(--ink);
-        --radius: 18px;
-        --mono: "SFMono-Regular", "Cascadia Code", "Roboto Mono", Consolas,
-          monospace;
-        --sans: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI",
-          sans-serif;
+        color-scheme: light;
+        --background: #ffffff;
+        --foreground: #171717;
+        --muted: #666666;
+        --subtle: #fafafa;
+        --border: #e5e5e5;
+        --mono: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+        --sans: Arial, Helvetica, sans-serif;
       }
 
       * {
@@ -44,704 +32,253 @@
       body {
         min-width: 320px;
         margin: 0;
-        background:
-          linear-gradient(rgba(21, 21, 21, 0.045) 1px, transparent 1px),
-          linear-gradient(90deg, rgba(21, 21, 21, 0.045) 1px, transparent 1px),
-          var(--paper);
-        background-size: 32px 32px;
-        color: var(--ink);
+        background: var(--background);
+        color: var(--foreground);
         font-family: var(--sans);
-        font-size: 16px;
-        line-height: 1.55;
+        -webkit-font-smoothing: antialiased;
       }
 
       a {
         color: inherit;
       }
 
-      code,
-      pre {
-        font-family: var(--mono);
+      .page {
+        width: min(760px, calc(100% - 48px));
+        margin-left: clamp(24px, 8vw, 120px);
       }
 
-      code {
-        font-size: 0.92em;
-      }
-
-      .wrap {
-        width: min(1120px, calc(100% - 40px));
-        margin-inline: auto;
-      }
-
-      .site-header {
-        position: sticky;
-        z-index: 20;
-        top: 0;
-        border-bottom: 2px solid var(--line);
-        background: rgba(244, 241, 232, 0.9);
-        backdrop-filter: blur(14px);
-      }
-
-      .nav {
+      header {
         display: flex;
-        min-height: 68px;
+        height: 72px;
         align-items: center;
         justify-content: space-between;
-        gap: 24px;
+        border-bottom: 1px solid var(--border);
       }
 
       .brand {
-        display: inline-flex;
-        align-items: center;
-        gap: 11px;
-        color: var(--ink);
-        font-family: var(--mono);
-        font-size: 0.92rem;
-        font-weight: 750;
-        letter-spacing: -0.03em;
+        font-size: 15px;
+        font-weight: 600;
+        letter-spacing: -0.02em;
         text-decoration: none;
       }
 
-      .brand-mark {
-        display: grid;
-        width: 28px;
-        height: 28px;
-        place-items: center;
-        border: 2px solid var(--line);
-        background: var(--lime);
-        box-shadow: 3px 3px 0 var(--ink);
-        font-size: 0.76rem;
-      }
-
-      .nav-links {
-        display: flex;
-        align-items: center;
-        gap: 22px;
-        font-size: 0.88rem;
-        font-weight: 700;
-      }
-
-      .nav-links a {
-        text-underline-offset: 4px;
-      }
-
-      .nav-links a:hover {
-        text-decoration-thickness: 2px;
-      }
-
-      .nav-cta {
-        border: 2px solid var(--line);
-        background: var(--ink);
-        color: white;
-        padding: 8px 13px;
+      .github {
+        color: var(--muted);
+        font-size: 14px;
         text-decoration: none;
       }
 
-      .announcement {
-        border-bottom: 2px solid var(--line);
-        background: var(--lime);
+      .github:hover,
+      footer a:hover {
+        color: var(--foreground);
       }
 
-      .announcement .wrap {
-        display: flex;
-        min-height: 38px;
-        align-items: center;
-        justify-content: center;
-        gap: 10px;
-        font-family: var(--mono);
-        font-size: 0.75rem;
-        font-weight: 700;
-        letter-spacing: 0.02em;
-        text-align: center;
+      main {
+        padding: 112px 0 80px;
       }
 
       .hero {
-        display: grid;
-        grid-template-columns: minmax(0, 1.08fr) minmax(380px, 0.92fr);
-        gap: 64px;
-        align-items: center;
-        padding-block: 96px 110px;
-      }
-
-      .eyebrow {
-        display: inline-flex;
-        align-items: center;
-        gap: 10px;
-        margin: 0 0 20px;
-        font-family: var(--mono);
-        font-size: 0.76rem;
-        font-weight: 750;
-        letter-spacing: 0.12em;
-        text-transform: uppercase;
-      }
-
-      .eyebrow::before {
-        width: 10px;
-        height: 10px;
-        border: 2px solid var(--line);
-        background: var(--orange);
-        content: "";
+        max-width: 720px;
+        padding-bottom: 104px;
       }
 
       h1,
       h2,
-      h3,
       p {
         margin-top: 0;
       }
 
-      h1,
-      h2,
-      h3 {
-        letter-spacing: -0.055em;
-      }
-
       h1 {
-        max-width: 700px;
-        margin-bottom: 26px;
-        font-size: clamp(3.5rem, 8vw, 7.2rem);
-        font-weight: 780;
-        line-height: 0.88;
-      }
-
-      h1 .accent {
-        position: relative;
-        z-index: 0;
-        white-space: nowrap;
-      }
-
-      h1 .accent::after {
-        position: absolute;
-        z-index: -1;
-        right: -0.05em;
-        bottom: 0.04em;
-        left: -0.04em;
-        height: 0.25em;
-        background: var(--orange);
-        content: "";
-        transform: rotate(-1.5deg);
+        max-width: 680px;
+        margin-bottom: 28px;
+        font-size: clamp(54px, 8vw, 88px);
+        font-weight: 650;
+        letter-spacing: -0.075em;
+        line-height: 0.96;
       }
 
       .lede {
-        max-width: 620px;
-        margin-bottom: 32px;
-        color: #494842;
-        font-size: clamp(1.08rem, 2vw, 1.28rem);
+        max-width: 590px;
+        margin-bottom: 34px;
+        color: var(--muted);
+        font-size: 20px;
+        letter-spacing: -0.025em;
+        line-height: 1.5;
       }
 
       .actions {
         display: flex;
         flex-wrap: wrap;
-        gap: 12px;
+        gap: 10px;
       }
 
       .button {
         display: inline-flex;
-        min-height: 48px;
+        height: 44px;
         align-items: center;
         justify-content: center;
-        border: 2px solid var(--line);
-        padding: 10px 18px;
-        font-weight: 750;
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 0 17px;
+        font-size: 14px;
+        font-weight: 500;
         text-decoration: none;
-        transition: transform 140ms ease, box-shadow 140ms ease;
-      }
-
-      .button:hover {
-        transform: translate(-2px, -2px);
       }
 
       .button-primary {
-        background: var(--ink);
-        box-shadow: 5px 5px 0 var(--orange);
+        border-color: var(--foreground);
+        background: var(--foreground);
         color: white;
+      }
+
+      .button:hover {
+        background: #f2f2f2;
       }
 
       .button-primary:hover {
-        box-shadow: 7px 7px 0 var(--orange);
+        background: #333333;
       }
 
-      .button-secondary {
-        background: var(--paper-raised);
-        box-shadow: 5px 5px 0 var(--ink);
+      section:not(.hero) {
+        border-top: 1px solid var(--border);
+        padding: 72px 0;
       }
 
-      .button-secondary:hover {
-        box-shadow: 7px 7px 0 var(--ink);
+      h2 {
+        margin-bottom: 14px;
+        font-size: 28px;
+        font-weight: 600;
+        letter-spacing: -0.045em;
       }
 
-      .monitor {
-        overflow: hidden;
-        border: 2px solid var(--line);
-        border-radius: var(--radius);
-        background: #111;
-        box-shadow: 10px 10px 0 var(--orange);
-        color: #f8f8f4;
-        transform: rotate(1.2deg);
-      }
-
-      .monitor-bar {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        border-bottom: 1px solid #353535;
-        padding: 13px 16px;
-        color: #a9a9a2;
-        font-family: var(--mono);
-        font-size: 0.72rem;
-      }
-
-      .window-dots {
-        display: flex;
-        gap: 6px;
-      }
-
-      .window-dots i {
-        width: 9px;
-        height: 9px;
-        border-radius: 999px;
-        background: #4b4b4b;
-      }
-
-      .window-dots i:first-child {
-        background: var(--orange);
-      }
-
-      .monitor-body {
-        padding: 16px 18px 22px;
-        font-family: var(--mono);
-        font-size: clamp(0.72rem, 1.4vw, 0.84rem);
-      }
-
-      .event {
-        display: grid;
-        grid-template-columns: 9px minmax(130px, auto) 1fr;
-        gap: 12px;
-        align-items: start;
-        border-bottom: 1px solid #292929;
-        padding: 13px 0;
-      }
-
-      .event:last-child {
-        border-bottom: 0;
-      }
-
-      .event-dot {
-        width: 8px;
-        height: 8px;
-        margin-top: 5px;
-        border-radius: 999px;
-        background: var(--lime);
-        box-shadow: 0 0 0 3px rgba(216, 255, 82, 0.13);
-      }
-
-      .event.error .event-dot {
-        background: var(--orange);
-        box-shadow: 0 0 0 3px rgba(255, 92, 53, 0.15);
-      }
-
-      .event-type {
-        color: white;
-        font-weight: 700;
-      }
-
-      .event-detail {
-        color: #92928c;
-        text-align: right;
-      }
-
-      .monitor-status {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        margin-top: 16px;
-        border: 1px solid #3a3a3a;
-        background: #191919;
-        padding: 11px 12px;
-        color: #b9b9b2;
-      }
-
-      .monitor-status strong {
-        color: var(--lime);
-        font-weight: 650;
-      }
-
-      .section {
-        border-top: 2px solid var(--line);
-        padding-block: 92px;
-      }
-
-      .section-heading {
-        display: grid;
-        grid-template-columns: 0.7fr 1.3fr;
-        gap: 60px;
-        align-items: end;
-        margin-bottom: 44px;
-      }
-
-      .section-heading h2 {
-        margin-bottom: 0;
-        font-size: clamp(2.7rem, 6vw, 5.4rem);
-        line-height: 0.95;
-      }
-
-      .section-heading p {
+      .section-copy {
         max-width: 580px;
-        margin: 0;
+        margin-bottom: 30px;
         color: var(--muted);
-        font-size: 1.08rem;
+        font-size: 16px;
+        line-height: 1.6;
       }
 
-      .feature-grid {
-        display: grid;
-        grid-template-columns: repeat(3, 1fr);
-        gap: 18px;
-      }
-
-      .feature {
-        min-height: 250px;
-        border: 2px solid var(--line);
-        background: var(--paper-raised);
-        padding: 25px;
-      }
-
-      .feature:nth-child(2) {
-        background: var(--lime);
-      }
-
-      .feature:nth-child(3) {
-        background: #dfe9ff;
-      }
-
-      .feature-number {
-        display: block;
-        margin-bottom: 54px;
-        font-family: var(--mono);
-        font-size: 0.72rem;
-        font-weight: 750;
-      }
-
-      .feature h3 {
-        margin-bottom: 12px;
-        font-size: 1.55rem;
-      }
-
-      .feature p {
-        margin-bottom: 0;
-        color: #4d4c46;
-      }
-
-      .quickstart {
-        background: var(--ink);
-        color: white;
-      }
-
-      .quickstart .section-heading p {
-        color: #aaa9a1;
-      }
-
-      .quickstart .eyebrow::before {
-        background: var(--lime);
-        border-color: white;
-      }
-
-      .install-line {
+      .install {
         display: flex;
+        width: min(100%, 500px);
+        min-height: 52px;
         align-items: center;
-        justify-content: space-between;
-        gap: 20px;
-        margin-bottom: 20px;
-        border: 1px solid #414141;
-        background: #0d0d0d;
-        padding: 18px 20px;
-        color: #d7d7d0;
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        background: var(--subtle);
+        padding: 0 17px;
         font-family: var(--mono);
+        font-size: 13px;
       }
 
-      .install-line span:first-child {
-        color: #74746f;
+      .prompt {
+        margin-right: 12px;
+        color: #999999;
         user-select: none;
       }
 
-      .install-line strong {
-        color: var(--lime);
-        font-weight: 500;
-      }
-
-      .install-line small {
-        color: #74746f;
-      }
-
-      .code-grid {
-        display: grid;
-        grid-template-columns: 1fr 1fr;
-        gap: 18px;
-      }
-
-      .code-card {
-        overflow: hidden;
-        border: 1px solid #414141;
-        background: #0d0d0d;
-      }
-
-      .code-card-header {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        border-bottom: 1px solid #333;
-        padding: 12px 16px;
-        color: #8d8d87;
-        font-family: var(--mono);
-        font-size: 0.72rem;
-        letter-spacing: 0.08em;
-        text-transform: uppercase;
-      }
-
-      .code-card-header b {
-        color: var(--orange);
-        font-weight: 600;
-      }
-
-      pre {
+      .code {
         overflow-x: auto;
-        min-height: 265px;
+        width: 100%;
         margin: 0;
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        background: var(--subtle);
         padding: 22px;
-        font-size: 0.8rem;
+        font-family: var(--mono);
+        font-size: 13px;
         line-height: 1.7;
         tab-size: 2;
       }
 
-      .token-keyword,
-      .token-string {
-        color: var(--lime);
-      }
-
-      .token-function {
-        color: #8eb3ff;
-      }
-
-      .token-comment {
-        color: #777771;
-      }
-
-      .compatibility {
+      .capabilities {
         display: grid;
-        grid-template-columns: 1fr 1fr;
-        gap: 18px;
+        gap: 0;
+        margin: 34px 0 0;
+        padding: 0;
+        border-top: 1px solid var(--border);
+        list-style: none;
       }
 
-      .compat-card {
-        border: 2px solid var(--line);
-        background: var(--paper-raised);
-        padding: 30px;
-      }
-
-      .compat-card h3 {
-        margin-bottom: 20px;
-        font-size: 2rem;
-      }
-
-      .version-list {
+      .capabilities li {
         display: grid;
-        gap: 10px;
+        grid-template-columns: 150px 1fr;
+        gap: 28px;
+        border-bottom: 1px solid var(--border);
+        padding: 22px 0;
+        font-size: 14px;
+        line-height: 1.55;
       }
 
-      .version-row {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        border-top: 1px solid #c9c6bb;
-        padding-top: 10px;
-        font-family: var(--mono);
-        font-size: 0.82rem;
+      .capabilities strong {
+        font-weight: 550;
       }
 
-      .status {
-        display: inline-flex;
-        align-items: center;
-        gap: 7px;
-        color: #365200;
-        font-weight: 750;
-      }
-
-      .status::before {
-        width: 8px;
-        height: 8px;
-        border-radius: 999px;
-        background: #73a900;
-        content: "";
-      }
-
-      .event-cloud {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 9px;
-      }
-
-      .event-cloud code {
-        border: 1px solid var(--line);
-        background: var(--paper);
-        padding: 7px 9px;
-        font-size: 0.73rem;
-      }
-
-      .closing {
-        display: grid;
-        grid-template-columns: 1fr auto;
-        gap: 40px;
-        align-items: center;
-        border: 2px solid var(--line);
-        background: var(--orange);
-        box-shadow: var(--shadow);
-        padding: clamp(28px, 6vw, 58px);
-      }
-
-      .closing h2 {
-        max-width: 750px;
-        margin-bottom: 12px;
-        font-size: clamp(2.5rem, 6vw, 5.6rem);
-        line-height: 0.92;
-      }
-
-      .closing p {
-        max-width: 600px;
-        margin-bottom: 0;
-        font-weight: 600;
-      }
-
-      .closing .button {
-        background: var(--paper-raised);
-        box-shadow: 5px 5px 0 var(--ink);
-        white-space: nowrap;
+      .capabilities span {
+        color: var(--muted);
       }
 
       footer {
-        padding-block: 46px;
-      }
-
-      .footer-row {
         display: flex;
+        min-height: 110px;
         align-items: center;
         justify-content: space-between;
-        gap: 28px;
-        font-family: var(--mono);
-        font-size: 0.75rem;
+        border-top: 1px solid var(--border);
+        color: var(--muted);
+        font-size: 13px;
       }
 
       .footer-links {
         display: flex;
-        flex-wrap: wrap;
         gap: 18px;
       }
 
-      @media (max-width: 860px) {
-        .hero,
-        .section-heading,
-        .code-grid,
-        .compatibility {
-          grid-template-columns: 1fr;
+      footer a {
+        text-decoration: none;
+      }
+
+      @media (max-width: 640px) {
+        .page {
+          width: calc(100% - 32px);
+          margin-left: 16px;
+        }
+
+        header {
+          height: 64px;
+        }
+
+        main {
+          padding-top: 76px;
         }
 
         .hero {
-          gap: 52px;
-          padding-block: 72px 88px;
-        }
-
-        .monitor {
-          width: min(100%, 620px);
-          transform: none;
-        }
-
-        .section-heading {
-          gap: 22px;
-        }
-
-        .feature-grid {
-          grid-template-columns: 1fr;
-        }
-
-        .feature {
-          min-height: 0;
-        }
-
-        .feature-number {
-          margin-bottom: 34px;
-        }
-
-        .closing {
-          grid-template-columns: 1fr;
-        }
-
-        .closing .button {
-          width: fit-content;
-        }
-      }
-
-      @media (max-width: 600px) {
-        .wrap {
-          width: min(100% - 24px, 1120px);
-        }
-
-        .nav {
-          min-height: 60px;
-        }
-
-        .nav-links > a:not(.nav-cta) {
-          display: none;
-        }
-
-        .announcement .wrap {
-          padding-block: 7px;
+          padding-bottom: 76px;
         }
 
         h1 {
-          font-size: clamp(3.2rem, 18vw, 5.2rem);
+          font-size: clamp(48px, 15vw, 68px);
         }
 
-        .hero {
-          grid-template-columns: minmax(0, 1fr);
+        .lede {
+          font-size: 18px;
         }
 
-        .monitor-body {
-          padding-inline: 13px;
+        section:not(.hero) {
+          padding: 56px 0;
         }
 
-        .event {
-          grid-template-columns: 8px 1fr;
+        .capabilities li {
+          grid-template-columns: 1fr;
+          gap: 7px;
         }
 
-        .event-detail {
-          grid-column: 2;
-          text-align: left;
-        }
-
-        .section {
-          padding-block: 70px;
-        }
-
-        .install-line {
+        footer {
           align-items: flex-start;
           flex-direction: column;
-        }
-
-        pre {
-          min-height: 0;
-          padding: 17px;
-          font-size: 0.72rem;
-        }
-
-        .compat-card {
-          padding: 22px;
-        }
-
-        .closing {
-          box-shadow: 5px 5px 0 var(--ink);
-        }
-
-        .footer-row {
-          align-items: flex-start;
-          flex-direction: column;
+          justify-content: center;
+          gap: 12px;
+          padding: 28px 0;
         }
       }
 
@@ -749,272 +286,89 @@
         html {
           scroll-behavior: auto;
         }
-
-        .button {
-          transition: none;
-        }
       }
     </style>
   </head>
   <body>
-    <header class="site-header">
-      <nav class="nav wrap" aria-label="Primary navigation">
-        <a class="brand" href="#top" aria-label="next-dev-bridge home">
-          <span class="brand-mark" aria-hidden="true">↯</span>
-          <span>next-dev-bridge</span>
-        </a>
-        <div class="nav-links">
-          <a href="#quickstart">Quickstart</a>
-          <a
-            href="https://github.com/vercel-labs/next-dev-bridge/tree/main/examples"
-            >Examples</a
-          >
-          <a
-            class="nav-cta"
-            href="https://github.com/vercel-labs/next-dev-bridge"
-            >GitHub ↗</a
-          >
-        </div>
-      </nav>
-    </header>
+    <div class="page">
+      <header>
+        <a class="brand" href="#top">next-dev-bridge</a>
+        <a class="github" href="https://github.com/vercel-labs/next-dev-bridge"
+          >GitHub ↗</a
+        >
+      </header>
 
-    <div class="announcement">
-      <div class="wrap">
-        <span>●</span>
-        <span>Next.js 16.2 + 16.3 HMR endpoints supported</span>
-      </div>
-    </div>
-
-    <main id="top">
-      <section class="hero wrap">
-        <div>
-          <p class="eyebrow">Development signal, normalized</p>
-          <h1>Know when Next <span class="accent">breaks.</span></h1>
+      <main id="top">
+        <section class="hero">
+          <h1>Development state, made readable.</h1>
           <p class="lede">
-            Turn Next.js HMR noise into readable build and runtime events for
-            CLIs, preview shells, agents, and custom development tools.
+            A small bridge from Next.js development events to the tools you
+            build around them.
           </p>
           <div class="actions">
-            <a class="button button-primary" href="#quickstart">Get started</a>
-            <a
-              class="button button-secondary"
-              href="https://github.com/vercel-labs/next-dev-bridge/tree/main/examples"
-              >Browse examples</a
-            >
-          </div>
-        </div>
-
-        <div class="monitor" aria-label="Example next-dev-bridge event stream">
-          <div class="monitor-bar">
-            <span class="window-dots" aria-hidden="true"><i></i><i></i><i></i></span>
-            <span>localhost:3000 · event stream</span>
-          </div>
-          <div class="monitor-body">
-            <div class="event">
-              <span class="event-dot"></span>
-              <span class="event-type">session:connected</span>
-              <span class="event-detail">/_next/hmr</span>
-            </div>
-            <div class="event">
-              <span class="event-dot"></span>
-              <span class="event-type">build:ready</span>
-              <span class="event-detail">warnings: 0</span>
-            </div>
-            <div class="event error">
-              <span class="event-dot"></span>
-              <span class="event-type">build:error</span>
-              <span class="event-detail">page.tsx:18:7</span>
-            </div>
-            <div class="event">
-              <span class="event-dot"></span>
-              <span class="event-type">build:recovered</span>
-              <span class="event-detail">42 ms</span>
-            </div>
-            <div class="monitor-status">
-              <span>current state</span>
-              <strong>● HEALTHY</strong>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      <section class="section">
-        <div class="wrap">
-          <div class="section-heading">
-            <div>
-              <p class="eyebrow">One small bridge</p>
-              <h2>Less parsing. More signal.</h2>
-            </div>
-            <p>
-              Next development servers emit useful information, but the transport
-              is built for Next itself. next-dev-bridge gives tools a compact,
-              stable vocabulary instead.
-            </p>
-          </div>
-
-          <div class="feature-grid">
-            <article class="feature">
-              <span class="feature-number">01 / BUILD STATE</span>
-              <h3>Errors you can render</h3>
-              <p>
-                Receive formatted compiler errors, warnings, recovery, and ready
-                states without rebuilding Next's overlay protocol.
-              </p>
-            </article>
-            <article class="feature">
-              <span class="feature-number">02 / RUNTIME STATE</span>
-              <h3>Browser failures included</h3>
-              <p>
-                Capture uncaught errors, rejected promises, and reported errors
-                with source-mapped frames when Next can provide them.
-              </p>
-            </article>
-            <article class="feature">
-              <span class="feature-number">03 / YOUR UI</span>
-              <h3>Bring your own surface</h3>
-              <p>
-                Feed an agent, terminal, iframe shell, status panel, or any other
-                development interface that needs trustworthy state.
-              </p>
-            </article>
-          </div>
-        </div>
-      </section>
-
-      <section class="section quickstart" id="quickstart">
-        <div class="wrap">
-          <div class="section-heading">
-            <div>
-              <p class="eyebrow">Quickstart</p>
-              <h2>Connect in a few lines.</h2>
-            </div>
-            <p>
-              Use the Node observer beside a running dev server, or the browser
-              observer inside a preview. The runnable setups stay in the examples
-              directory.
-            </p>
-          </div>
-
-          <div class="install-line" aria-label="Installation command">
-            <code><span>$</span> npm install <strong>next-dev-bridge</strong></code>
-            <small>ESM · Node 18+</small>
-          </div>
-
-          <div class="code-grid">
-            <article class="code-card">
-              <div class="code-card-header">
-                <span>Node observer</span><b>server.mjs</b>
-              </div>
-              <pre><code><span class="token-keyword">import</span> { connect } <span class="token-keyword">from</span> <span class="token-string">'next-dev-bridge'</span>
-
-<span class="token-keyword">const</span> connection = <span class="token-function">connect</span>(
-  { url: <span class="token-string">'http://localhost:3000'</span> },
-  (event, state) =&gt; {
-    <span class="token-keyword">if</span> (event.type === <span class="token-string">'build:error'</span>) {
-      console.<span class="token-function">log</span>(event.errors)
-    }
-  }
-)
-
-process.<span class="token-function">once</span>(<span class="token-string">'SIGINT'</span>, () =&gt; {
-  connection.<span class="token-function">stop</span>()
-})</code></pre>
-            </article>
-
-            <article class="code-card">
-              <div class="code-card-header">
-                <span>Browser observer</span><b>preview.ts</b>
-              </div>
-              <pre><code><span class="token-keyword">import</span> { observeNextDev } <span class="token-keyword">from</span>
-  <span class="token-string">'next-dev-bridge/client'</span>
-
-<span class="token-keyword">const</span> observer = <span class="token-function">observeNextDev</span>(
-  (event, state) =&gt; {
-    window.parent.<span class="token-function">postMessage</span>({
-      type: <span class="token-string">'next-dev-bridge:event'</span>,
-      event,
-      state,
-    }, <span class="token-string">'*'</span>)
-  }
-)
-
-window.<span class="token-function">addEventListener</span>(<span class="token-string">'pagehide'</span>, () =&gt;
-  observer.<span class="token-function">stop</span>()
-)</code></pre>
-            </article>
-          </div>
-        </div>
-      </section>
-
-      <section class="section">
-        <div class="wrap">
-          <div class="section-heading">
-            <div>
-              <p class="eyebrow">The contract</p>
-              <h2>Small surface. Clear states.</h2>
-            </div>
-            <p>
-              The bridge owns connection lifecycle and state tracking, while your
-              code decides how events should look and what should happen next.
-            </p>
-          </div>
-
-          <div class="compatibility">
-            <article class="compat-card">
-              <h3>Compatibility</h3>
-              <div class="version-list">
-                <div class="version-row">
-                  <span>Next.js 16.2</span><span class="status">tested</span>
-                </div>
-                <div class="version-row">
-                  <span>Next.js 16.3</span><span class="status">tested</span>
-                </div>
-                <div class="version-row">
-                  <span>Node.js 18+</span><span class="status">supported</span>
-                </div>
-              </div>
-            </article>
-
-            <article class="compat-card">
-              <h3>Readable events</h3>
-              <div class="event-cloud" aria-label="Common event names">
-                <code>build:ready</code>
-                <code>build:error</code>
-                <code>build:recovered</code>
-                <code>runtime:error</code>
-                <code>session:connected</code>
-                <code>session:disconnected</code>
-                <code>observer:error</code>
-              </div>
-            </article>
-          </div>
-        </div>
-      </section>
-
-      <section class="section">
-        <div class="wrap">
-          <div class="closing">
-            <div>
-              <p class="eyebrow">Open source · MIT</p>
-              <h2>Build a calmer dev loop.</h2>
-              <p>
-                Read the API reference, inspect the local examples, and wire Next
-                development state into your own tool.
-              </p>
-            </div>
+            <a class="button button-primary" href="#start">Get started</a>
             <a
               class="button"
-              href="https://github.com/vercel-labs/next-dev-bridge"
-              >View on GitHub ↗</a
+              href="https://github.com/vercel-labs/next-dev-bridge/tree/main/examples"
+              >View examples</a
             >
           </div>
-        </div>
-      </section>
-    </main>
+        </section>
 
-    <footer>
-      <div class="footer-row wrap">
-        <span>next-dev-bridge / MIT</span>
+        <section id="start">
+          <h2>Install</h2>
+          <p class="section-copy">
+            Connect to a running development server from Node or observe build
+            and runtime state in the browser.
+          </p>
+          <div class="install" aria-label="Installation command">
+            <span class="prompt">$</span>
+            <code>npm install next-dev-bridge</code>
+          </div>
+        </section>
+
+        <section>
+          <h2>Observe</h2>
+          <p class="section-copy">
+            Receive a compact event stream and decide how your interface should
+            respond.
+          </p>
+          <pre class="code"><code>import { connect } from 'next-dev-bridge'
+
+const connection = connect(
+  { url: 'http://localhost:3000' },
+  (event, state) =&gt; {
+    console.log(event.type, state.phase)
+  }
+)
+
+process.once('SIGINT', () =&gt; connection.stop())</code></pre>
+        </section>
+
+        <section>
+          <h2>One clear interface</h2>
+          <p class="section-copy">
+            Keep framework transport details out of your development UI.
+          </p>
+          <ul class="capabilities">
+            <li>
+              <strong>Build state</strong>
+              <span>Ready, failed, updated, and recovered.</span>
+            </li>
+            <li>
+              <strong>Runtime errors</strong>
+              <span>Browser failures with mapped frames when available.</span>
+            </li>
+            <li>
+              <strong>Any surface</strong>
+              <span>Use it in a CLI, preview shell, agent, or custom UI.</span>
+            </li>
+          </ul>
+        </section>
+      </main>
+
+      <footer>
+        <span>MIT licensed</span>
         <div class="footer-links">
           <a href="https://www.npmjs.com/package/next-dev-bridge">npm</a>
           <a href="https://github.com/vercel-labs/next-dev-bridge/blob/main/docs/API.md"
@@ -1023,9 +377,8 @@ window.<span class="token-function">addEventListener</span>(<span class="token-s
           <a href="https://github.com/vercel-labs/next-dev-bridge/tree/main/examples"
             >Examples</a
           >
-          <a href="https://github.com/vercel-labs/next-dev-bridge">Source</a>
         </div>
-      </div>
-    </footer>
+      </footer>
+    </div>
   </body>
 </html>

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": null,
+  "outputDirectory": "site",
+  "cleanUrls": true
+}


### PR DESCRIPTION
## Summary

- add a redesigned, dependency-free `site/index.html`
- deploy only `site/` through the root `vercel.json`
- keep the interactive Next.js viewer as a local example under `examples/`
- update repository and example documentation to separate the website from runnable usage

## Verification

- rendered at 1440px and 390px
- confirmed no mobile horizontal overflow
- confirmed the page loads zero scripts
- `bun run test:unit`
- `bun run build`

## Deployment note

The Vercel project should use the repository root as its Root Directory so the root `vercel.json` publishes `site/`.